### PR TITLE
Fixed a bug that sends password hash when authentication is disabled

### DIFF
--- a/lib/pj_link/client.rb
+++ b/lib/pj_link/client.rb
@@ -140,7 +140,7 @@ module PjLink
           end
         end
 
-        @password_hash = Digest::MD5.hexdigest("#{key}#{password}") if auth_required
+        @password_hash = Digest::MD5.hexdigest("#{key}#{password}") unless auth_required == "0"
         self
       end
 


### PR DESCRIPTION
The problem of the current code is that pj_link fails to detect correctly that the authentication is
disabled at the first reply parsing, and always tries to do the authentication process,
even when the projector is configured to disable it.

According to section 5.2 of the PjLink specification published at
http://pjlink.jbmia.or.jp/data/5-1_PJLink_20131210.pdf , the initial reply sent
from projector/display shall be "PJLINK 0\r" in case of no authentication. Getting that reply, auth_required variable will be set to string "0", not integer 0 nor false, and that's why conditions need to be modified from "if auth_required" to "unless auth_required == "0"" as is in this patch. 

The modified code is confirmed to solve the problem with Ricoh WX4130N projector as well as PJLink test software distributed at http://pjlink.jbmia.or.jp/dl-class2.html
